### PR TITLE
Aggiunta del tag `name:en` per la scelta del nome #3

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -90,7 +90,7 @@ Layer:
             way, name, religion, way_pixels, is_building,
             COALESCE(aeroway, golf, amenity, wetland, power, landuse, leisure, man_made, "natural", shop, tourism, highway, railway) AS feature
           FROM (SELECT
-              way, COALESCE((tags->('name:it')), name, '') as name,
+              way, COALESCE((tags->('name:it')), (tags->('name:en')), name, '') as name,
               ('aeroway_' || (CASE WHEN aeroway IN ('apron', 'aerodrome') THEN aeroway END)) AS aeroway,
               ('golf_' || (CASE WHEN (tags->'golf') IN ('rough', 'fairway', 'driving_range', 'water_hazard', 'green', 'bunker', 'tee') THEN tags->'golf' ELSE NULL END)) AS golf,
               ('amenity_' || (CASE WHEN amenity IN ('bicycle_parking', 'motorcycle_parking', 'university', 'college', 'school', 'taxi',
@@ -211,7 +211,7 @@ Layer:
         (SELECT
             way,
             waterway,
-            COALESCE((tags->('name:it')), name, '') as name,
+            COALESCE((tags->('name:it')), (tags->('name:en')), name, '') as name,
             CASE WHEN tags->'intermittent' IN ('yes')
               OR tags->'seasonal' IN ('yes', 'spring', 'summer', 'autumn', 'winter', 'wet_season', 'dry_season')
               THEN 'yes' ELSE 'no' END AS int_intermittent,
@@ -1201,10 +1201,10 @@ Layer:
         (SELECT
             ST_PointOnSurface(way) AS way,
             way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels,
-            COALESCE((tags->('name:it')),  name, '') as name
+            COALESCE((tags->('name:it')), (tags->('name:en')),  name, '') as name
           FROM planet_osm_polygon
           WHERE ST_PointOnSurface(way) && !bbox!
-            AND COALESCE((tags->('name:it')),  name, NULL) IS NOT NULL
+            AND COALESCE((tags->('name:it')), (tags->('name:en')),  name, NULL) IS NOT NULL
             AND boundary = 'administrative'
             AND admin_level = '2'
             AND way_area > 100*POW(!scale_denominator!*0.001*0.28,2)
@@ -1222,14 +1222,14 @@ Layer:
       table: |-
         (SELECT
             way,
-            COALESCE((tags->('name:it')),  name, '') as name,
+            COALESCE((tags->('name:it')), (tags->('name:en')),  name, '') as name,
             CASE
               WHEN (tags->'population' ~ '^[0-9]{1,8}$') THEN (tags->'population')::INTEGER ELSE 0
             END as population,
             round(ascii(md5(osm_id::text)) / 55) AS dir -- base direction factor on geometry to be consistent across metatiles
           FROM planet_osm_point
           WHERE place IN ('city', 'town', 'village', 'hamlet')
-            AND COALESCE((tags->('name:it')),  name, NULL) IS NOT NULL
+            AND COALESCE((tags->('name:it')), (tags->('name:en')),  name, NULL) IS NOT NULL
             AND tags @> 'capital=>yes'
           ORDER BY population DESC
         ) AS capital_names
@@ -1245,12 +1245,12 @@ Layer:
         (SELECT
             ST_PointOnSurface(way) AS way,
             way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels,
-            COALESCE((tags->('name:it')),  name, '') as name,
+            COALESCE((tags->('name:it')), (tags->('name:en')),  name, '') as name,
             admin_level,
             ref
           FROM planet_osm_polygon
           WHERE ST_PointOnSurface(way) && !bbox!
-            AND COALESCE((tags->('name:it')),  name, NULL) IS NOT NULL
+            AND COALESCE((tags->('name:it')), (tags->('name:en')),  name, NULL) IS NOT NULL
             AND boundary = 'administrative'
             AND admin_level = '4'
             AND way_area > 3000*POW(!scale_denominator!*0.001*0.28,2)
@@ -1280,7 +1280,7 @@ Layer:
                 osm_id,
                 way,
                 place,
-                COALESCE((tags->('name:it')),  name, '') as name,
+                COALESCE((tags->('name:it')), (tags->('name:en')),  name, '') as name,
                 (
                   (CASE
                     WHEN (tags->'population' ~ '^[0-9]{1,8}$') THEN (tags->'population')::INTEGER
@@ -1296,7 +1296,7 @@ Layer:
                 ) AS score
               FROM planet_osm_point
               WHERE place IN ('city', 'town')
-                AND COALESCE((tags->('name:it')),  name, NULL) IS NOT NULL
+                AND COALESCE((tags->('name:it')), (tags->('name:en')),  name, NULL) IS NOT NULL
                 AND NOT (tags @> 'capital=>yes')
             ) as p
           ORDER BY score DESC, length(name) DESC, name
@@ -1314,13 +1314,13 @@ Layer:
         (SELECT
             way,
             place,
-            COALESCE((tags->('name:it')),  name, '') as name
+            COALESCE((tags->('name:it')), (tags->('name:en')),  name, '') as name
           FROM planet_osm_point
           WHERE place IN ('village', 'hamlet')
-             AND COALESCE((tags->('name:it')),  name, NULL) IS NOT NULL
+             AND COALESCE((tags->('name:it')), (tags->('name:en')),  name, NULL) IS NOT NULL
              AND NOT tags @> 'capital=>yes'
              OR (place IN ('suburb', 'quarter', 'neighbourhood', 'isolated_dwelling', 'farm')
-             ) AND COALESCE((tags->('name:it')),  name, NULL) IS NOT NULL
+             ) AND COALESCE((tags->('name:it')), (tags->('name:en')),  name, NULL) IS NOT NULL
           ORDER BY CASE
               WHEN place = 'suburb' THEN 7
               WHEN place = 'village' THEN 6
@@ -1352,7 +1352,7 @@ Layer:
           FROM
           (SELECT
               ST_PointOnSurface(way) AS way,
-              COALESCE((tags->('name:it')),  name, '') as name,
+              COALESCE((tags->('name:it')), (tags->('name:en')),  name, '') as name,
               ref,
               railway,
               aerialway,
@@ -1364,7 +1364,7 @@ Layer:
           UNION ALL
           SELECT
               way,
-              COALESCE((tags->('name:it')),  name, '') as name,
+              COALESCE((tags->('name:it')), (tags->('name:en')),  name, '') as name,
               ref,
               railway,
               aerialway,
@@ -1398,7 +1398,7 @@ Layer:
             highway,
             junction,
             ref,
-            COALESCE((tags->('name:it')),  name, '') as name,
+            COALESCE((tags->('name:it')), (tags->('name:en')),  name, '') as name,
             NULL AS way_pixels
           FROM planet_osm_point
           WHERE way && !bbox!
@@ -1409,7 +1409,7 @@ Layer:
             highway,
             junction,
             ref,
-            COALESCE((tags->('name:it')),  name, '') as name,
+            COALESCE((tags->('name:it')), (tags->('name:en')),  name, '') as name,
             way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels
           FROM planet_osm_polygon
           WHERE way && !bbox! -- Not ST_PointOnSurface(way) because name might be NULL
@@ -1429,10 +1429,10 @@ Layer:
             ST_PointOnSurface(way) AS way,
             way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels,
             man_made,
-            COALESCE((tags->('name:it')),  name, '') as name
+            COALESCE((tags->('name:it')), (tags->('name:en')),  name, '') as name
           FROM planet_osm_polygon
           WHERE ST_PointOnSurface(way) && !bbox!
-            AND COALESCE((tags->('name:it')),  name, NULL) IS NOT NULL
+            AND COALESCE((tags->('name:it')), (tags->('name:en')),  name, NULL) IS NOT NULL
             AND man_made = 'bridge'
             AND way_area > 125*POW(!scale_denominator!*0.001*0.28,2)
             AND way_area < 768000*POW(!scale_denominator!*0.001*0.28,2)
@@ -1449,11 +1449,11 @@ Layer:
         (SELECT
             ST_PointOnSurface(way) AS way,
             way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels,
-            COALESCE((tags->('name:it')),  name, '') as name,
+            COALESCE((tags->('name:it')), (tags->('name:en')),  name, '') as name,
             admin_level
           FROM planet_osm_polygon
           WHERE ST_PointOnSurface(way) && !bbox!
-            AND COALESCE((tags->('name:it')),  name, NULL) IS NOT NULL
+            AND COALESCE((tags->('name:it')), (tags->('name:en')),  name, NULL) IS NOT NULL
             AND boundary = 'administrative'
             AND admin_level IN ('5', '6')
             AND way_area > 12000*POW(!scale_denominator!*0.001*0.28,2)
@@ -1615,7 +1615,7 @@ Layer:
             FROM
               (SELECT
                   ST_PointOnSurface(way) AS way,
-                  COALESCE((tags->('name:it')), name, '') as name,
+                  COALESCE((tags->('name:it')), (tags->('name:en')), name, '') as name,
                   access,
                   aeroway,
                   amenity,
@@ -1644,7 +1644,7 @@ Layer:
               UNION ALL
               SELECT
                   way,
-                  COALESCE((tags->('name:it')), name, '') as name,
+                  COALESCE((tags->('name:it')), (tags->('name:en')), name, '') as name,
                   access,
                   aeroway,
                   amenity,
@@ -1826,10 +1826,10 @@ Layer:
             ST_PointOnSurface(way) AS way,
             way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels,
             highway,
-            COALESCE((tags->('name:it')), name, '') as name
+            COALESCE((tags->('name:it')), (tags->('name:en')), name, '') as name
           FROM planet_osm_polygon
           WHERE ST_PointOnSurface(way) && !bbox!
-            AND COALESCE((tags->('name:it')), name, NULL) IS NOT NULL
+            AND COALESCE((tags->('name:it')), (tags->('name:en')), name, NULL) IS NOT NULL
             AND (highway IN ('pedestrian', 'footway', 'service', 'living_street', 'platform')
               OR (railway IN ('platform')
                   AND (tags->'location' NOT IN ('underground') OR (tags->'location') IS NULL)
@@ -1852,7 +1852,7 @@ Layer:
             CASE WHEN substr(highway, length(highway)-4, 5) = '_link' THEN substr(highway, 0, length(highway)-4) ELSE highway END,
             CASE WHEN (tunnel = 'yes' OR tunnel = 'building_passage' OR covered = 'yes') THEN 'yes' ELSE 'no' END AS tunnel,
             construction,
-            COALESCE((tags->('name:it')), name, '') as name,
+            COALESCE((tags->('name:it')), (tags->('name:en')), name, '') as name,
             CASE
               WHEN oneway IN ('yes', '-1') THEN oneway
               WHEN junction IN ('roundabout') AND (oneway IS NULL OR NOT oneway IN ('no', 'reversible')) THEN 'yes'
@@ -1861,7 +1861,7 @@ Layer:
           FROM planet_osm_line l
           WHERE highway IN ('motorway', 'motorway_link', 'trunk', 'trunk_link', 'primary', 'primary_link', 'secondary', 'secondary_link', 'tertiary',
                             'tertiary_link', 'residential', 'unclassified', 'road', 'service', 'pedestrian', 'raceway', 'living_street', 'construction')
-            AND (COALESCE((tags->('name:it')), name, NULL) IS NOT NULL
+            AND (COALESCE((tags->('name:it')), (tags->('name:en')), name, NULL) IS NOT NULL
               OR oneway IN ('yes', '-1')
               OR junction IN ('roundabout'))
           ORDER BY
@@ -1884,7 +1884,7 @@ Layer:
             way,
             highway,
             construction,
-            COALESCE((tags->('name:it')), name, '') as name,
+            COALESCE((tags->('name:it')), (tags->('name:en')), name, '') as name,
             CASE
               WHEN oneway IN ('yes', '-1') THEN oneway
               WHEN junction IN ('roundabout') AND (oneway IS NULL OR NOT oneway IN ('no', 'reversible')) THEN 'yes'
@@ -1893,7 +1893,7 @@ Layer:
             bicycle
           FROM planet_osm_line
           WHERE highway IN ('bridleway', 'footway', 'cycleway', 'path', 'track', 'steps', 'construction')
-            AND (COALESCE((tags->('name:it')), name, NULL) IS NOT NULL
+            AND (COALESCE((tags->('name:it')), (tags->('name:en')), name, NULL) IS NOT NULL
               OR oneway IN ('yes', '-1')
               OR junction IN ('roundabout'))
         ) AS paths_text_name
@@ -1915,13 +1915,13 @@ Layer:
             tags->'highspeed' as highspeed,
             tags->'usage' as usage,
             construction,
-            COALESCE((tags->('name:it')), name, '') as name
+            COALESCE((tags->('name:it')), (tags->('name:en')), name, '') as name
           FROM planet_osm_line l
           WHERE railway IN ('rail', 'subway', 'narrow_gauge', 'light_rail', 'preserved', 'funicular',
                             'monorail', 'miniature', 'tram', 'disused', 'construction')
             AND (tunnel IS NULL OR NOT tunnel IN ('yes', 'building_passage'))
             AND highway IS NULL -- Prevent duplicate rendering
-            AND COALESCE((tags->('name:it')), name, NULL) IS NOT NULL
+            AND COALESCE((tags->('name:it')), (tags->('name:en')), name, NULL) IS NOT NULL
           ORDER BY
             z_order DESC, -- put important rails first
             COALESCE(layer, 0), -- put top layered rails first
@@ -1995,11 +1995,11 @@ Layer:
                                        THEN boundary END,
               'leisure_' || CASE WHEN leisure IN ('nature_reserve') THEN leisure END
             ) AS feature,
-            COALESCE((tags->('name:it')), name, '') as name,
+            COALESCE((tags->('name:it')), (tags->('name:en')), name, '') as name,
             CASE WHEN building = 'no' OR building IS NULL THEN 'no' ELSE 'yes' END AS is_building -- always no with the where conditions
           FROM planet_osm_polygon
           WHERE ST_PointOnSurface(way) && !bbox!
-            AND COALESCE((tags->('name:it')), name, NULL) IS NOT NULL
+            AND COALESCE((tags->('name:it')), (tags->('name:en')), name, NULL) IS NOT NULL
             AND (landuse IN ('forest', 'military', 'farmland')
               OR military IN ('danger_area')
               OR "natural" IN ('wood', 'glacier', 'sand', 'scree', 'shingle', 'bare_rock', 'water', 'bay', 'strait')
@@ -2026,7 +2026,7 @@ Layer:
             NULL as way_pixels,
             COALESCE('aerialway_' || aerialway, 'attraction_' || CASE WHEN tags @> 'attraction=>water_slide' THEN 'water_slide' END, 'leisure_' || leisure, 'man_made_' || man_made, 'waterway_' || waterway, 'natural_' || "natural", 'golf_' || (tags->'golf')) AS feature,
             access,
-            COALESCE((tags->('name:it')), name, '') as name,
+            COALESCE((tags->('name:it')), (tags->('name:en')), name, '') as name,
             tags->'operator' as operator,
             ref,
             NULL AS way_area,
@@ -2041,7 +2041,7 @@ Layer:
               OR leisure IN ('slipway', 'track')
               OR waterway IN ('dam', 'weir')
               OR "natural" IN ('arete', 'cliff', 'ridge'))
-            AND COALESCE((tags->('name:it')), name, NULL) IS NOT NULL
+            AND COALESCE((tags->('name:it')), (tags->('name:en')), name, NULL) IS NOT NULL
             OR (tags @> 'golf=>hole' AND ref IS NOT NULL)
         ) AS text_line
     properties:
@@ -2063,12 +2063,12 @@ Layer:
       <<: *osm2pgsql
       table: |-
         (SELECT
-            COALESCE((tags->('name:it')), name, '') as name,
+            COALESCE((tags->('name:it')), (tags->('name:en')), name, '') as name,
             ST_PointOnSurface(way) AS way,
             way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels
           FROM planet_osm_polygon
           WHERE ST_PointOnSurface(way) && !bbox!
-            AND COALESCE((tags->('name:it')), name, NULL) IS NOT NULL
+            AND COALESCE((tags->('name:it')), (tags->('name:en')), name, NULL) IS NOT NULL
             AND building IS NOT NULL
             AND building NOT IN ('no')
             AND way_area < 4000000*POW(!scale_denominator!*0.001*0.28,2)
@@ -2132,7 +2132,7 @@ Layer:
             way,
             waterway,
             lock,
-            COALESCE((tags->('name:it')), name, '') as name,
+            COALESCE((tags->('name:it')), (tags->('name:en')), name, '') as name,
             "natural",
             tags->'lock_name' AS lock_name,
             CASE WHEN tags->'intermittent' IN ('yes')
@@ -2145,7 +2145,7 @@ Layer:
           WHERE (waterway IN ('river', 'canal', 'stream', 'drain', 'ditch')
                  OR "natural" IN ('bay', 'strait'))
             AND (tunnel IS NULL OR tunnel != 'culvert')
-            AND COALESCE((tags->('name:it')), name, NULL) IS NOT NULL
+            AND COALESCE((tags->('name:it')), (tags->('name:en')), name, NULL) IS NOT NULL
           ORDER BY COALESCE(layer,0)
         ) AS water_lines_text
     properties:
@@ -2158,11 +2158,11 @@ Layer:
       table: |-
         (SELECT
             way,
-            COALESCE((tags->('name:it')), name, '') as name
+            COALESCE((tags->('name:it')), (tags->('name:en')), name, '') as name
           FROM planet_osm_line
           WHERE route = 'ferry'
             AND osm_id > 0
-            AND COALESCE((tags->('name:it')), name, NULL) IS NOT NULL
+            AND COALESCE((tags->('name:it')), (tags->('name:en')), name, NULL) IS NOT NULL
         ) AS ferry_routes_text
     properties:
       minzoom: 13
@@ -2174,13 +2174,13 @@ Layer:
       table: |-
         (SELECT
             way,
-            COALESCE((tags->('name:it')), name, '') as name,
+            COALESCE((tags->('name:it')), (tags->('name:en')), name, '') as name,
             admin_level,
             way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels
           FROM planet_osm_polygon
           WHERE boundary = 'administrative'
             AND admin_level IN ('1', '2', '3', '4', '5', '6', '7', '8', '9', '10')
-            AND COALESCE((tags->('name:it')), name, NULL) IS NOT NULL
+            AND COALESCE((tags->('name:it')), (tags->('name:en')), name, NULL) IS NOT NULL
             AND osm_id < 0
             AND way_area > 196000*POW(!scale_denominator!*0.001*0.28,2)
           ORDER BY admin_level::integer ASC, way_area DESC
@@ -2195,7 +2195,7 @@ Layer:
       table: |-
         (SELECT
             way,
-            COALESCE((tags->('name:it')), name, '') as name,
+            COALESCE((tags->('name:it')), (tags->('name:en')), name, '') as name,
             boundary,
             tags->'protect_class' AS protect_class,
             way_area/NULLIF(POW(!scale_denominator!*0.001*0.28,2),0) AS way_pixels
@@ -2203,7 +2203,7 @@ Layer:
           WHERE (boundary IN ('aboriginal_lands', 'national_park')
                  OR leisure = 'nature_reserve'
                  OR (boundary = 'protected_area' AND tags->'protect_class' IN ('1','1a','1b','2','3','4','5','6')))
-            AND COALESCE((tags->('name:it')), name, NULL) IS NOT NULL
+            AND COALESCE((tags->('name:it')), (tags->('name:en')), name, NULL) IS NOT NULL
         ) AS protected_areas_text
     properties:
       minzoom: 13
@@ -2229,7 +2229,7 @@ Layer:
             FROM
               (SELECT
                   ST_PointOnSurface(way) AS way,
-                  COALESCE((tags->('name:it')), name, '') as name,
+                  COALESCE((tags->('name:it')), (tags->('name:en')), name, '') as name,
                   access,
                   amenity,
                   barrier,
@@ -2245,7 +2245,7 @@ Layer:
               UNION ALL
               SELECT
                   way,
-                  COALESCE((tags->('name:it')), name, '') as name,
+                  COALESCE((tags->('name:it')), (tags->('name:en')), name, '') as name,
                   access,
                   amenity,
                   barrier,


### PR DESCRIPTION
Fixes #3 

## Changes proposed in this pull request:
- Aggiunta del tag `name:en` nella scelta del nome di un luogo se il tag `name:it` non è presente

## Review
@lucadelu se ti fa piacere puoi verificare che la modifica fatta sia coerente con la richiesta, mi sono basato sulla tua modifica https://github.com/osmItalia/openstreetmap-carto/commit/24c161ddbeb68d3b27817f03f5c991ea35c8e03c
